### PR TITLE
docs(ror-senior-dev): harden take-home assignment against AI assistance

### DIFF
--- a/ror-senior-dev/README.md
+++ b/ror-senior-dev/README.md
@@ -1,3 +1,12 @@
+## Using AI
+
+**Use AI — we expect it. We're evaluating how you direct it, not whether you can
+avoid it.**
+
+In the next phase we will ask you to walk us through your solution and explain
+the decisions behind it. You should be able to explain what you did and why —
+candidates who can't explain their own submission will not advance.
+
 ## Background
 
 Shypple is a freight forwarder company. That means we help other companies to

--- a/ror-senior-dev/README.md
+++ b/ror-senior-dev/README.md
@@ -145,15 +145,29 @@ fastest
 
 ### Project Requirements
 
-1. Please, create one single branch for all the changes.
-2. Make sure your app run on docker and all the dependencies are included on it
-3. Please send a zip file with the solution to this email address, j.souza@shypple.com, once you're done.
-4. The solution must work with standard input and output (stdin and stdout).
-5. For indirect routes, the solution should handle more than two legs.
+1. The solution must be written in Ruby.
+2. Please, create one single branch for all the changes.
+3. Make sure your app run on docker and all the dependencies are included on it
+4. Please send a zip file with the solution to this email address, j.souza@shypple.com, once you're done.
+5. The solution must work with standard input and output (stdin and stdout).
+6. For indirect routes, the solution should handle more than two legs.
 
 You should provide a solution that make possible to scale because new requirements will come soon.
 
-4. SLD-0004 - coming soon
+#### (4) SLD-0004 - *Acceptance criteria*: Save a search now, fulfill it later.
+
+A user may search for a route we have no option for yet (no direct or indirect
+path between origin and destination for the given criteria). Instead of simply
+returning an empty result, the system should **save** that search request.
+
+Later, a new MapReduce feed arrives with more sailings. Any previously saved
+search that can **now** be fulfilled should be surfaced back to the user.
+
+It is up to you to decide *how* to persist saved searches and *how* to inform
+the user once a match becomes available (remember: Docker is the only thing we
+can assume is installed). Choose the approach you think best fits the problem
+and **document your assumptions and the trade-offs you considered.**
+
 5. DRY-0005 - coming soon
 6. TDD-0006 - coming soon
 
@@ -179,6 +193,16 @@ between two specific locations, such as from one port to another. For example,
 if a shipment travels from Shanghai to Rotterdam with a stopover in Barcelona,
 the journey consists of two legs: Shanghai to Barcelona and Barcelona to
 Rotterdam.
+
+#### Assumptions & Data Quality
+
+The MapReduce feed is aggregated from multiple upstream providers, so the data is
+not guaranteed to be clean. For example, the same sailing may appear more than
+once with conflicting rates from different feeds — it is up to you to decide which
+one wins and to justify it.
+
+The data and spec are deliberately incomplete in places, as real tickets are.
+Document any assumptions you made and any questions you'd ask the PO.
 
 #### We are here to help
 

--- a/ror-senior-dev/response.json
+++ b/ror-senior-dev/response.json
@@ -86,6 +86,11 @@
       "rate_currency": "USD"
     },
     {
+      "sailing_code": "MNOP",
+      "rate": "812.00",
+      "rate_currency": "USD"
+    },
+    {
       "sailing_code": "QRST",
       "rate": "761.96",
       "rate_currency": "EUR"


### PR DESCRIPTION
## Why

In the age of AI, candidates can one-shot the current RoR senior take-home (clean, SOLID, well-tested) by pasting the brief into an LLM, leaving little interview leverage. These changes shift the assignment toward the judgment AI can't fake — handling ambiguity, dirty data, and stateful design — while keeping it a reasonable take-home.

## Changes

1. **Ruby is now explicit.** The README only implied it via the folder name; now it's the first project requirement.

2. **Planted a conflicting duplicate rate.** `response.json` now reports `MNOP` twice with different amounts (`456.78` vs `812.00` USD), as if merged from two feeds. MNOP is the current cheapest direct, so the dedup rule a candidate picks flips the `cheapest-direct` answer between MNOP (€410.11) and ABCD (€523.36). They can't ignore it — and how they resolve/justify it is the signal.

3. **"Assumptions & Data Quality" section.** Tells candidates the data and spec are deliberately incomplete (as real tickets are) and asks them to document assumptions made and questions they'd ask the PO. This writeup is meant to seed the live interview.

4. **New ticket SLD-0004 — save-a-search, fulfill-later.** A search with no available route should be saved, then surfaced to the user once a later feed makes it fulfillable. This breaks the stateless script shape and forces a stateful design. Persistence and notification mechanism are left open on purpose — another documented-assumption signal, and rich live-interview follow-up territory (scale, concurrent feeds, re-resolve vs. existence-check).

## Intent

The take-home produces an artifact; the open-ended *why / what-if / how-would-it-scale* questions are deliberately kept out of the written spec and reserved for the live round, where AI leverage drops.